### PR TITLE
Allow ERB in ebay_client.yml so that API secret keys can be set in ENV

### DIFF
--- a/lib/ebay_client/configuration.rb
+++ b/lib/ebay_client/configuration.rb
@@ -55,7 +55,7 @@ class EbayClient::Configuration
   class << self
     def load(file)
       defaults = load_defaults
-      configs = YAML.load_file file
+      configs = YAML.load(ERB.new(File.read(file)).result)
 
       configs.each_pair do |env, presets|
         env_defaults = defaults[env] || {}


### PR DESCRIPTION
We need this so we don't have to put our eBay secrets in GitHub.