### PR TITLE
Add a staging config

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -20,6 +20,9 @@ development: &development
 test:
   <<: *development
 
+staging:
+  <<: *development
+
 production:
   <<: *defaults
   url: 'https://api.ebay.com/wsapi'


### PR DESCRIPTION
Many Rails apps use a staging environment for testing. Make sure that in these environments, there is a configuration.